### PR TITLE
User Role and User approval for Registration flow and Social Auth flow.

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -23,7 +23,7 @@ class OrganizationAdmin(admin.ModelAdmin):
 
 
 class CoreGroupAdmin(admin.ModelAdmin):
-    list_display = ('name', 'organization', 'is_global', 'is_org_level', 'is_default', 'permissions')
+    list_display = ('id', 'name', 'organization', 'is_global', 'is_org_level', 'is_default', 'permissions')
     display = 'Core Group'
     search_fields = ('name', 'organization__name', )
 

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -17,7 +17,7 @@ from oauth2_provider.models import AccessToken, Application, RefreshToken
 from core.email_utils import send_email, send_email_body
 
 from core.models import CoreUser, CoreGroup, EmailTemplate, LogicModule, Organization, PERMISSIONS_ORG_ADMIN, \
-    TEMPLATE_RESET_PASSWORD
+    TEMPLATE_RESET_PASSWORD, PERMISSIONS_VIEW_ONLY
 
 
 class LogicModuleSerializer(serializers.ModelSerializer):
@@ -278,3 +278,57 @@ class ApplicationSerializer(serializers.ModelSerializer):
         validated_data['client_id'] = secrets.token_urlsafe(75)
         validated_data['client_secret'] = secrets.token_urlsafe(190)
         return super(ApplicationSerializer, self).create(validated_data)
+
+
+class CoreUserUpdateOrganizationSerializer(serializers.ModelSerializer):
+    """ Let's user update his  organization_name,and email. Also this assigns permissions to users """
+
+    email = serializers.CharField(required=False)
+    organization_name = serializers.CharField(required=False)
+    core_groups = CoreGroupSerializer(read_only=True, many=True)
+    organization = OrganizationSerializer(read_only=True)
+
+    class Meta:
+        model = CoreUser
+        fields = ('id', 'core_user_uuid', 'first_name', 'last_name', 'email', 'username', 'is_active', 'title',
+                  'contact_info', 'privacy_disclaimer_accepted', 'organization_name', 'organization', 'core_groups',)
+
+    def update(self, instance, validated_data):
+
+        organization_name = validated_data.pop('organization_name')
+        instance.email = validated_data.get('email', instance.email)
+        organization, is_new_org = Organization.objects.get_or_create(name=organization_name)
+
+        # if the current user is the first user
+        if is_new_org:
+
+            # first update the org name for that user
+            instance.organization = organization
+            instance.save()
+            # now attach the user role as ADMIN
+            org_admin = CoreGroup.objects.get(organization=organization,
+                                              is_org_level=True,
+                                              permissions=PERMISSIONS_ORG_ADMIN)
+            instance.core_groups.add(org_admin)
+
+            # add requested groups to the user
+            # for group in core_groups:
+            #     instance.core_groups.add(group)
+
+        else:
+            instance.organization = organization
+            instance.save()
+            # now attach the user role as USER
+            org_user = CoreGroup.objects.get(organization=organization,
+                                             is_org_level=True,
+                                             permissions=PERMISSIONS_VIEW_ONLY)
+            print("org_admin", org_user)
+            instance.core_groups.add(org_user)
+
+            # add requested groups to the user
+            # for group in core_groups:
+            #     instance.core_groups.add(group)
+
+        # instance.save()
+
+        return instance

--- a/core/views/coreuser.py
+++ b/core/views/coreuser.py
@@ -17,7 +17,7 @@ from rest_framework.permissions import AllowAny
 from core.models import CoreUser, Organization
 from core.serializers import (CoreUserSerializer, CoreUserWritableSerializer, CoreUserInvitationSerializer,
                               CoreUserResetPasswordSerializer, CoreUserResetPasswordCheckSerializer,
-                              CoreUserResetPasswordConfirmSerializer,CoreUserUpdateOrganizationSerializer)
+                              CoreUserResetPasswordConfirmSerializer, CoreUserUpdateOrganizationSerializer)
 from core.permissions import AllowAuthenticatedRead, AllowOnlyOrgAdmin, IsOrgMember
 from core.swagger import (COREUSER_INVITE_RESPONSE, COREUSER_INVITE_CHECK_RESPONSE, COREUSER_RESETPASS_RESPONSE,
                           DETAIL_RESPONSE, SUCCESS_RESPONSE, TOKEN_QUERY_PARAM)
@@ -60,6 +60,7 @@ class CoreUserViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
         'reset_password': CoreUserResetPasswordSerializer,
         'reset_password_check': CoreUserResetPasswordCheckSerializer,
         'reset_password_confirm': CoreUserResetPasswordConfirmSerializer,
+        'update_org': CoreUserUpdateOrganizationSerializer,
     }
 
     def list(self, request, *args, **kwargs):
@@ -263,8 +264,6 @@ class CoreUserViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
     queryset = CoreUser.objects.all()
     permission_classes = (AllowAuthenticatedRead,)
 
-
-
     @action(detail=True, methods=['patch'], name='Update Organization')
     def update_org(self, request, pk=None, *args, **kwargs):
         """
@@ -276,4 +275,3 @@ class CoreUserViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data)
-

--- a/core/views/coreuser.py
+++ b/core/views/coreuser.py
@@ -264,8 +264,8 @@ class CoreUserViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
     queryset = CoreUser.objects.all()
     permission_classes = (AllowAuthenticatedRead,)
 
-    @action(detail=True, methods=['patch'], name='Update Organization')
-    def update_org(self, request, pk=None, *args, **kwargs):
+    @action(detail=False, methods=['patch'], name='Update Organization', url_path='update_org/(?P<pk>\d+)')
+    def update_info(self, request, pk=None, *args, **kwargs):
         """
         Update a user Organization
         """

--- a/core/views/coreuser.py
+++ b/core/views/coreuser.py
@@ -9,11 +9,15 @@ from rest_framework.response import Response
 import django_filters
 import jwt
 from drf_yasg.utils import swagger_auto_schema
+from django.http import Http404
+from rest_framework.views import APIView
+from rest_framework.permissions import AllowAny
+
 
 from core.models import CoreUser, Organization
 from core.serializers import (CoreUserSerializer, CoreUserWritableSerializer, CoreUserInvitationSerializer,
                               CoreUserResetPasswordSerializer, CoreUserResetPasswordCheckSerializer,
-                              CoreUserResetPasswordConfirmSerializer)
+                              CoreUserResetPasswordConfirmSerializer,CoreUserUpdateOrganizationSerializer)
 from core.permissions import AllowAuthenticatedRead, AllowOnlyOrgAdmin, IsOrgMember
 from core.swagger import (COREUSER_INVITE_RESPONSE, COREUSER_INVITE_CHECK_RESPONSE, COREUSER_RESETPASS_RESPONSE,
                           DETAIL_RESPONSE, SUCCESS_RESPONSE, TOKEN_QUERY_PARAM)
@@ -258,3 +262,18 @@ class CoreUserViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
     queryset = CoreUser.objects.all()
     permission_classes = (AllowAuthenticatedRead,)
+
+
+
+    @action(detail=True, methods=['patch'], name='Update Organization')
+    def update_org(self, request, pk=None, *args, **kwargs):
+        """
+        Update a user Organization
+        """
+        # the particular user in CoreUser table
+        user = self.get_object()
+        serializer = CoreUserUpdateOrganizationSerializer(user, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
+


### PR DESCRIPTION
User updates his organization name and an optional email field
In normal registration that the user is not auto approved(when he is the second person to join the organization)

++Additional Edit after initial review
changed url path to /coreuser/update_org/{id}/
ability to update email(double update email info)
save org name as lower
admin has only admin role  only 
update swagger docs name

