### PR TITLE
Update pop up org name

### DIFF
--- a/core/views/organization.py
+++ b/core/views/organization.py
@@ -3,7 +3,7 @@ import logging
 import django_filters
 from rest_framework import viewsets
 from rest_framework.response import Response
-
+from rest_framework.decorators import action
 from core.models import Organization
 from core.serializers import OrganizationSerializer
 from core.permissions import IsOrgMember
@@ -47,3 +47,19 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     permission_classes = (IsOrgMember,)
     queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
+
+    # /organization/names/
+    # send only the names
+    @action(detail=False, methods=['get'], name='Fetch Already existing Organization', url_path='names')
+    def fetch_existing_orgs(self, request, pk=None, *args, **kwargs):
+        """
+        Fetch Already existing Organizations in Buildly Core,
+        Any logged in user can access this
+        """
+        # all orgs in Buildly Core
+        queryset = Organization.objects.all()
+        names = list()
+        for record in queryset:
+            names.append(record.name)
+
+        return Response(names)


### PR DESCRIPTION
Lets user pick his Organization name, or by default  is attached to 'Default Organization'
Permissions flow remains as previous, if the user is first user in an organization he is by default an Admin to that org, else every other incoming user to that org will have "USER" permissions.
This PR also updates the fetch all organization names to " /organization/names/".
List of organization names are returned as ["Default Organization" ,"h for help"]

